### PR TITLE
Fix improper word-break for latin languages

### DIFF
--- a/src/components/ArticleList/components/ArticleCard.jsx
+++ b/src/components/ArticleList/components/ArticleCard.jsx
@@ -148,7 +148,7 @@ export default function ArticleCard({ article }) {
             <div className="flex flex-col gap-1 flex-1">
               <h3
                 className={cn(
-                  "card-title text-base font-semibold line-clamp-2 text-wrap break-words break-all",
+                  "card-title text-base font-semibold line-clamp-2 text-wrap break-words",
                   article.status === "read"
                     ? "text-content2-foreground"
                     : "text-foreground",


### PR DESCRIPTION
This commit addresses an issue with improper word-breaking in Latin languages, ensuring that words are correctly hyphenated and displayed across lines.