### PR TITLE
Add a new setting to disable text-clamping

### DIFF
--- a/src/components/ArticleList/components/ArticleCard.jsx
+++ b/src/components/ArticleList/components/ArticleCard.jsx
@@ -22,6 +22,7 @@ export default function ArticleCard({ article }) {
     cardImageSize,
     showFavicon,
     showReadingTime,
+    truncateTitles,
   } = useStore(settingsState);
   const hasBeenVisible = useRef(false);
   const { ripples, onClear, onPress } = useRipple();
@@ -148,10 +149,13 @@ export default function ArticleCard({ article }) {
             <div className="flex flex-col gap-1 flex-1">
               <h3
                 className={cn(
-                  "card-title text-base font-semibold line-clamp-2 text-wrap break-words break-all",
+                  "card-title text-base font-semibold text-wrap break-words",
                   article.status === "read"
                     ? "text-content2-foreground"
                     : "text-foreground",
+                  truncateTitles
+                    ? "line-clamp-2"
+                    : "",
                 )}
               >
                 {cleanTitle(article.title)}

--- a/src/components/Settings/Appearance.jsx
+++ b/src/components/Settings/Appearance.jsx
@@ -12,6 +12,7 @@ import {
   CircleDashed,
   Clock,
   LayoutList,
+  ListEnd,
   Rss,
   Square,
   Text,
@@ -29,6 +30,7 @@ export default function Appearance() {
     showFavicon,
     showTextPreview,
     showReadingTime,
+    truncateTitles,
     reduceMotion,
     interfaceFontSize,
   } = useStore(settingsState);
@@ -128,6 +130,17 @@ export default function Appearance() {
           }
           settingName="showReadingTime"
           settingValue={showReadingTime}
+        />
+        <Divider />
+        <SwitchItem
+          label={t("settings.appearance.truncateTitles")}
+          icon={
+            <SettingIcon variant="green">
+              <ListEnd />
+            </SettingIcon>
+          }
+          settingName="truncateTitles"
+          settingValue={truncateTitles}
         />
       </ItemWrapper>
 

--- a/src/i18n/locales/en-US.js
+++ b/src/i18n/locales/en-US.js
@@ -256,6 +256,7 @@ export default {
       showFavicon: "Display favicons",
       showTextPreview: "Text preview",
       showReadingTime: "Estimated reading time",
+      truncateTitles: "Truncate titles",
       codeBlock: "CODE BLOCK",
       showLineNumbers: "Show line numbers",
       forceDarkCodeTheme: "Force dark code",

--- a/src/i18n/locales/fr-FR.js
+++ b/src/i18n/locales/fr-FR.js
@@ -255,6 +255,7 @@ export default {
       showFavicon: "Afficher les favicons",
       showTextPreview: "Aperçu du texte",
       showReadingTime: "Temps de lecture estimé",
+      truncateTitles: "Tronquer les titres",
       codeBlock: "BLOC DE CODE",
       showLineNumbers: "Afficher les numéros de ligne",
       forceDarkCodeTheme: "Forcer le code sombre",

--- a/src/i18n/locales/tr-TR.js
+++ b/src/i18n/locales/tr-TR.js
@@ -256,6 +256,7 @@ export default {
       showFavicon: "Faviconları göster",
       showTextPreview: "Metin önizlemesi",
       showReadingTime: "Tahmini okuma süresi",
+      truncateTitles: "Başlıkları Kırp",
       codeBlock: "KOD BLOĞU",
       showLineNumbers: "Satır numaralarını göster",
       forceDarkCodeTheme: "Karanlık moda zorla",

--- a/src/i18n/locales/zh-CN.js
+++ b/src/i18n/locales/zh-CN.js
@@ -255,6 +255,7 @@ export default {
       showFavicon: "显示订阅图标",
       showTextPreview: "文本预览",
       showReadingTime: "估计阅读时间",
+      truncateTitles: "截断标题",
       codeBlock: "代码块",
       showLineNumbers: "显示行号",
       forceDarkCodeTheme: "强制深色主题",

--- a/src/stores/settingsStore.js
+++ b/src/stores/settingsStore.js
@@ -19,6 +19,7 @@ const defaultValue = {
   showFavicon: true,
   showTextPreview: true,
   showReadingTime: true,
+  truncateTitles: true,
   autoHideToolbar: false,
   syncInterval: "15", // 添加同步间隔设置，默认15分钟
   showLineNumbers: false,


### PR DESCRIPTION
This commit introduces a new setting that allows users to disable text-clamping in titles, to enhance readability.

Warning: I've added tr-TR & zh-CN using Mistral Le Chat. Translations might not be optimal.