### PR TITLE
Normalize Miniflux server URLs before API requests

### DIFF
--- a/src/api/miniflux.js
+++ b/src/api/miniflux.js
@@ -1,6 +1,5 @@
 import axios from "axios";
 import { authState, logout } from "@/stores/authStore";
-import { normalizeServerUrl } from "@/lib/url";
 import { toast } from "sonner";
 
 // 创建 axios 实例
@@ -8,7 +7,7 @@ const createApiClient = () => {
   const auth = authState.get();
 
   const client = axios.create({
-    baseURL: auth?.serverUrl ? normalizeServerUrl(auth.serverUrl) : "",
+    baseURL: auth?.serverUrl || "",
     headers:
       auth?.authType === "token"
         ? {
@@ -46,9 +45,7 @@ let apiClient = createApiClient();
 
 // 监听认证状态变化
 authState.listen((newAuth) => {
-  apiClient.defaults.baseURL = newAuth?.serverUrl
-    ? normalizeServerUrl(newAuth.serverUrl)
-    : "";
+  apiClient.defaults.baseURL = newAuth?.serverUrl || "";
   if (newAuth?.authType === "token") {
     apiClient.defaults.headers["X-Auth-Token"] = newAuth.token;
     delete apiClient.defaults.headers["Authorization"];

--- a/src/api/miniflux.js
+++ b/src/api/miniflux.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { authState, logout } from "@/stores/authStore";
+import { normalizeServerUrl } from "@/lib/url";
 import { toast } from "sonner";
 
 // 创建 axios 实例
@@ -7,7 +8,7 @@ const createApiClient = () => {
   const auth = authState.get();
 
   const client = axios.create({
-    baseURL: auth?.serverUrl || "",
+    baseURL: auth?.serverUrl ? normalizeServerUrl(auth.serverUrl) : "",
     headers:
       auth?.authType === "token"
         ? {
@@ -45,7 +46,9 @@ let apiClient = createApiClient();
 
 // 监听认证状态变化
 authState.listen((newAuth) => {
-  apiClient.defaults.baseURL = newAuth?.serverUrl || "";
+  apiClient.defaults.baseURL = newAuth?.serverUrl
+    ? normalizeServerUrl(newAuth.serverUrl)
+    : "";
   if (newAuth?.authType === "token") {
     apiClient.defaults.headers["X-Auth-Token"] = newAuth.token;
     delete apiClient.defaults.headers["Authorization"];

--- a/src/lib/url.js
+++ b/src/lib/url.js
@@ -1,9 +1,5 @@
 export function normalizeServerUrl(serverUrl) {
   return typeof serverUrl === "string"
-    ? serverUrl
-        .trim()
-        .replace(/\/+$/, "")
-        .replace(/\/v1$/, "")
-        .replace(/\/+$/, "")
+    ? serverUrl.trim().replace(/\/+(?:v1\/*)?$/, "")
     : "";
 }

--- a/src/lib/url.js
+++ b/src/lib/url.js
@@ -1,5 +1,5 @@
 export function normalizeServerUrl(serverUrl) {
   return typeof serverUrl === "string"
-    ? serverUrl.trim().replace(/\/+$/, "").replace(/\/v1$/i, "")
+    ? serverUrl.trim().replace(/\/+$/, "").replace(/\/v1$/, "")
     : "";
 }

--- a/src/lib/url.js
+++ b/src/lib/url.js
@@ -1,3 +1,5 @@
 export function normalizeServerUrl(serverUrl) {
-  return serverUrl.trim().replace(/\/+$/, "").replace(/\/v1$/i, "");
+  return typeof serverUrl === "string"
+    ? serverUrl.trim().replace(/\/+$/, "").replace(/\/v1$/i, "")
+    : "";
 }

--- a/src/lib/url.js
+++ b/src/lib/url.js
@@ -1,0 +1,3 @@
+export function normalizeServerUrl(serverUrl) {
+  return serverUrl.trim().replace(/\/+$/, "").replace(/\/v1$/i, "");
+}

--- a/src/lib/url.js
+++ b/src/lib/url.js
@@ -1,5 +1,9 @@
 export function normalizeServerUrl(serverUrl) {
   return typeof serverUrl === "string"
-    ? serverUrl.trim().replace(/\/+$/, "").replace(/\/v1$/, "")
+    ? serverUrl
+        .trim()
+        .replace(/\/+$/, "")
+        .replace(/\/v1$/, "")
+        .replace(/\/+$/, "")
     : "";
 }

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -15,7 +15,11 @@ export const authState = persistentAtom("auth", defaultValue, {
   encode: JSON.stringify,
   decode: (str) => {
     const storedValue = JSON.parse(str);
-    return { ...defaultValue, ...storedValue };
+    return {
+      ...defaultValue,
+      ...storedValue,
+      serverUrl: normalizeServerUrl(storedValue.serverUrl),
+    };
   },
 });
 

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -1,4 +1,5 @@
 import { persistentAtom } from "@nanostores/persistent";
+import { normalizeServerUrl } from "@/lib/url";
 import { stopAutoSync } from "./syncStore";
 
 const defaultValue = {
@@ -21,6 +22,7 @@ export const authState = persistentAtom("auth", defaultValue, {
 // 登录方法
 export async function login(serverUrl, username, password, token) {
   try {
+    const normalizedServerUrl = normalizeServerUrl(serverUrl);
     let headers = {};
     if (token) {
       headers["X-Auth-Token"] = token;
@@ -28,7 +30,7 @@ export async function login(serverUrl, username, password, token) {
       headers["Authorization"] = "Basic " + btoa(`${username}:${password}`);
     }
 
-    const response = await fetch(`${serverUrl}/v1/me`, {
+    const response = await fetch(`${normalizedServerUrl}/v1/me`, {
       headers,
     });
 
@@ -43,7 +45,7 @@ export async function login(serverUrl, username, password, token) {
 
     // 保存认证信息
     authState.set({
-      serverUrl,
+      serverUrl: normalizedServerUrl,
       username: user.username,
       password: token ? "" : password,
       token: token || "",

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -18,7 +18,9 @@ export const authState = persistentAtom("auth", defaultValue, {
     return {
       ...defaultValue,
       ...storedValue,
-      serverUrl: normalizeServerUrl(storedValue.serverUrl),
+      serverUrl: storedValue.serverUrl
+        ? normalizeServerUrl(storedValue.serverUrl)
+        : defaultValue.serverUrl,
     };
   },
 });


### PR DESCRIPTION
miniflux 上复制出来的 api 地址是  `https://example.com/v1/`

直接贴到我们的引导页里会有莫名其妙的报错

兼容一下