### PR TITLE
Respect default unread filter for feed article lists

### DIFF
--- a/src/components/ArticleList/ArticleList.jsx
+++ b/src/components/ArticleList/ArticleList.jsx
@@ -86,12 +86,12 @@ const ArticleList = () => {
     $lastSync,
   ]);
 
-  // 组件挂载时设置默认过滤器
+  // 进入文章列表时设置默认过滤器
   useEffect(() => {
-    if (!feedId && !categoryId && showUnreadByDefault) {
+    if (showUnreadByDefault && filter.get() !== "unread") {
       filter.set("unread");
     }
-  }, []);
+  }, [feedId, categoryId, showUnreadByDefault]);
 
   return (
     <div className="main-content flex">


### PR DESCRIPTION
设置中有个文章列表 - 默认显示未读文章，开了没有用，点开订阅之后，底部还是默认全部。
<img width="514" height="140" alt="image" src="https://github.com/user-attachments/assets/9b0a24c0-8f81-45f5-9ec3-8843eb0691e8" />
